### PR TITLE
support cas

### DIFF
--- a/double_write_cache_stores.gemspec
+++ b/double_write_cache_stores.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "activesupport", "= 3.2.15"
-  spec.add_development_dependency "dalli", "= 2.6.4"
+  spec.add_development_dependency "dalli", "= 2.7.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "padrino", "0.10.7"
   spec.add_development_dependency "tilt", "1.3.7"

--- a/lib/double_write_cache_stores/client.rb
+++ b/lib/double_write_cache_stores/client.rb
@@ -17,6 +17,20 @@ class DoubleWriteCacheStores::Client
     get_or_read_method_call key
   end
 
+  def get_cas(key)
+    @read_and_write_store.get_cas key
+  end
+
+  def set_cas(key, value, cas, options = nil)
+    cas_unique = @read_and_write_store.set_cas key, value, cas, options
+
+    if @write_only_store && cas_unique
+      set_or_write_method_call @write_only_store, key, value, options
+    end
+
+    cas_unique
+  end
+
   def read(key)
     get_or_read_method_call key
   end

--- a/spec/double_write_cache_stores/client_spec.rb
+++ b/spec/double_write_cache_stores/client_spec.rb
@@ -151,4 +151,60 @@ describe DoubleWriteCacheStores::Client do
     end
   end
 
+  describe "#get_cas" do
+    context "when support get_cas method in backend cache store" do
+      let :support_get_cas_cache_store do
+        read_and_write = ::Dalli::Client.new(['localhost:11211'])
+        write_only = ::Dalli::Client.new(['localhost:21211'])
+        DoubleWriteCacheStores::Client.new read_and_write, write_only
+      end
+
+      before do
+        support_get_cas_cache_store.set 'cas-dalli-key', 'cas-dalli-value'
+      end
+
+      it 'example' do
+        expect(support_get_cas_cache_store.get_cas('cas-dalli-key')[0]).to eq 'cas-dalli-value'
+        expect(support_get_cas_cache_store.get_cas('cas-dalli-key')[1]).to be_kind_of(Integer)
+      end
+    end
+
+    context "when doesn't support get_cas method in backend cache store" do
+      let :not_support_get_cas_cache_store do
+        DoubleWriteCacheStores::Client.new ActiveSupport::Cache::DalliStore.new('localhost:11211'), ActiveSupport::Cache::DalliStore.new('localhost:21211')
+      end
+
+      it 'should raise NoMethodError' do
+        expect{ not_support_get_cas_cache_store.get_cas 'cas-key' }.to raise_error(NoMethodError)
+      end
+    end
+  end
+
+  describe "#set_cas" do
+    context "when support set_cas method in backend cache store" do
+      let :support_set_cas_cache_store do
+        read_and_write = ::Dalli::Client.new(['localhost:11211'])
+        write_only = ::Dalli::Client.new(['localhost:21211'])
+        DoubleWriteCacheStores::Client.new read_and_write, write_only
+      end
+      let :cas_unique do
+        support_set_cas_cache_store.set('cas-dalli-key', 'cas-value')
+        support_set_cas_cache_store.get_cas('cas-dalli-key')[1]
+      end
+
+      it 'example' do
+        expect(support_set_cas_cache_store.set_cas('cas-dalli-key', 'cas-dalli-value', cas_unique)).to be_kind_of(Integer)
+      end
+    end
+
+    context "when doesn't support set_cas method in backend cache store" do
+      let :not_support_set_cas_cache_store do
+        DoubleWriteCacheStores::Client.new ActiveSupport::Cache::DalliStore.new('localhost:11211'), ActiveSupport::Cache::DalliStore.new('localhost:21211')
+      end
+
+      it 'should raise NoMethodError' do
+        expect{ not_support_set_cas_cache_store.set_cas('cas-key', 'cas-value', 1) }.to raise_error(NoMethodError)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'double_write_cache_stores'
 require 'active_support'
 require 'dalli'
+require 'dalli/cas/client'
 require 'pry'
 require 'padrino-cache'
 


### PR DESCRIPTION
dalli 2.7.0 で追加された`get_cas`/`set_cas`をサポートします。